### PR TITLE
fixes a division by 0 issue in case if there are no coverItems in crossCoverage bins

### DIFF
--- a/src/ucis/report/coverage_report_builder.py
+++ b/src/ucis/report/coverage_report_builder.py
@@ -140,7 +140,7 @@ class CoverageReportBuilder(object):
 
             total += 1
 
-        cr_r.coverage = round((100*num_hit)/total, 2)
+        if total > 0: cr_r.coverage = round((100*num_hit)/total, 2)
         
         return cr_r        
         


### PR DESCRIPTION
I use FC4SC and when reporting cross coverages it does not write items which are not hit. This leads to a division by zero exeception.