### PR TITLE
change XML import to handle cgInstances

### DIFF
--- a/src/ucis/report/coverage_report_builder.py
+++ b/src/ucis/report/coverage_report_builder.py
@@ -43,7 +43,7 @@ class CoverageReportBuilder(object):
             div += cg.weight
             self.report.covergroups.append(cg)
             self.report.covergroup_m[cg.instname] = cg
-        self.report.coverage = round(coverage/div, 2)
+        self.report.coverage = coverage/div
             
     def build_covergroup(self, cg_n)->CoverageReport.Covergroup:
         cg_r = CoverageReport.Covergroup(
@@ -74,9 +74,13 @@ class CoverageReportBuilder(object):
             coverage += cr.coverage * cr.weight
             div += cr.weight
             
-        coverage /= div
+        for cg in cg_r.covergroups:
+            coverage += cg.coverage * cg.weight
+            div += cg.weight
             
-        cg_r.coverage = round(coverage, 2)
+        if div > 0: coverage /= div
+
+        cg_r.coverage = coverage
         
         return cg_r
 
@@ -116,7 +120,7 @@ class CoverageReportBuilder(object):
                     cvg_data.at_least,
                     cvg_data.data))
 
-        cp_r.coverage = round((100*num_hit)/total, 2)
+        cp_r.coverage = (100*num_hit)/total
         
         return cp_r
         
@@ -140,7 +144,7 @@ class CoverageReportBuilder(object):
 
             total += 1
 
-        if total > 0: cr_r.coverage = round((100*num_hit)/total, 2)
+        if total > 0: cr_r.coverage = (100*num_hit)/total
         
         return cr_r        
         

--- a/src/ucis/report/text_coverage_report_formatter.py
+++ b/src/ucis/report/text_coverage_report_formatter.py
@@ -26,7 +26,7 @@ class TextCoverageReportFormatter(object):
                           is_inst):
         self.writeln("%s %s : %f%%", 
                 "INST" if is_inst else "TYPE",
-                cg.name, cg.coverage)
+                cg.name, round(cg.coverage, 2))
         
         with self.indent():
             for cp in cg.coverpoints:
@@ -38,7 +38,7 @@ class TextCoverageReportFormatter(object):
                 self.report_covergroup(cg_i, True)
             
     def report_coverpoint(self, cp : CoverageReport.Coverpoint):
-        self.writeln("CVP %s : %f%%", cp.name, cp.coverage)
+        self.writeln("CVP %s : %f%%", cp.name, round(cp.coverage))
         
         if self.details:
             self.writeln("Bins:")
@@ -54,7 +54,7 @@ class TextCoverageReportFormatter(object):
                     self.report_bins(cp.illegal_bins)
 
     def report_cross(self, cr : CoverageReport.Cross):
-        self.writeln("CROSS %s : %f%%", cr.name, cr.coverage)
+        self.writeln("CROSS %s : %f%%", cr.name, round(cr.coverage))
         
         if self.details:
             self.writeln("Bins:")

--- a/src/ucis/xml/xml_reader.py
+++ b/src/ucis/xml/xml_reader.py
@@ -144,24 +144,29 @@ class XmlReader():
             type_scope)
         
         for cg in instN.iter("covergroupCoverage"):
-            self.readCovergroup(cg, inst_scope)
+            self.readCovergroup(cg, inst_scope, module_scope_name)
 
 #        self.setIntIfEx(instN, ret.setAli, name)
 
-    def readCovergroup(self, cg, inst_scope):
+    def readCovergroup(self, cg, inst_scope, module_scope_name):
         # This entry is for a given covergroup type
         
         cg_typescope = None
         covergroup_scope = None
         
-        for cgN in cg.iter("cgInstance"):
+        instances = [i for i in cg.iter("cgInstance")]
+        if len(instances) == 1:
+            cg_typescope = inst_scope.createCovergroup(
+                self.getAttr(instances[0], "name", "default"),
+                None,
+                1,
+                UCIS_OTHER)
+        else:
+            cg_typescope = inst_scope.createCovergroup(
+                module_scope_name, None, 1, UCIS_OTHER)
+        for cgN in instances:
             srcinfo = None
-            if cg_typescope is None:
-                cg_typescope = inst_scope.createCovergroup(
-                    self.getAttr(cgN, "name", "default"),
-                    srcinfo,
-                    1,
-                    UCIS_OTHER)
+            if len(instances) == 1:
                 covergroup_scope = cg_typescope
             else:
                 covergroup_scope = cg_typescope.createCoverInstance(


### PR DESCRIPTION
The PR changes the import of XML into the MemDB. If there is only 1 cgInstance in a covergroupCoverage the behavior is the same. If there a several cgInstances they all are imported as list of instances. The report_builder has been updated to correctly handle this and also sum the coverage numbers of the instances. The rounding has been moved to the formatter as premature rounding might lead to issues when summing up large databases.
Attached is a simple xml version illustrating this, using pyucis-viewer it looks like
![image](https://user-images.githubusercontent.com/437271/174739760-5301f8c5-87e5-4cb4-bda1-00642cf28298.png)
(Separately I will provide a fix for the rounding in viewer)
[test_coverage.xml.zip](https://github.com/fvutils/pyucis/files/8946660/test_coverage.xml.zip)
