### PR TITLE
Fix incomplete merge with multiple covergroups in a covergroupCoverage

### DIFF
--- a/src/ucis/merge/db_merger.py
+++ b/src/ucis/merge/db_merger.py
@@ -86,10 +86,9 @@ class DbMerger(object):
                 name = src_cg.getScopeName()
                 
                 if name not in cg_name_m.keys():
-                    scope_l = [None]*len(src_scopes)
-                    cg_name_m[name] = scope_l
-                    cg_name_l.append(name)
-                cg_name_m[name][i] = src_cg
+                  cg_name_m[name] = []
+                  cg_name_l.append(name)
+                cg_name_m[name].append(src_cg)
 
         for name in cg_name_l:                
             src_cg_l = list(filter(lambda cg: cg is not None, cg_name_m[name]))


### PR DESCRIPTION
Previous merge behaviour did not fully merge coverage files when multiple covergroups existed under a single `<covergroupCoverage>`.

Consider the following XML file generated when collecting coverage
<details>
<summary> cov.xml </summary>

```xml
<!-- cov.xml -->
<UCIS xmlns:ucis="http://www.w3.org/2001/XMLSchema-instance" writtenBy="kasper" writtenTime="2023-09-19T00:00:00" ucisVersion="1.0">
  <sourceFiles fileName="__null__file__" id="1"/>
  <sourceFiles fileName="&lt;unknown&gt;" id="2"/>
  <sourceFiles fileName="/home/kasper/cocotb/gen_coverage.py" id="3"/>
  <historyNodes historyNodeId="0" logicalName="logicalName" physicalName="foo.ucis" kind="HistoryNodeKind.TEST" testStatus="true" simtime="0.0" timeunit="ns" runCwd="." cpuTime="0.0" seed="0" cmd="" args="" compulsory="0" date="2023-09-19T16:42:34" userName="user" cost="0.0" toolCategory="UCIS:simulator" ucisVersion="1.0" vendorId="unknown" vendorTool="unknown" vendorToolVersion="unknown"/>
  <instanceCoverages name="cg_inst" key="0">
    <id file="1" line="1" inlineCount="1"/>
    <covergroupCoverage>
      <cgInstance name="uvm_test_top.env.master.coverage.cg_addr" key="0">
        <options/>
        <cgId cgName="uvm_test_top.env.master.coverage.cg_addr" moduleName="uvm_test_top.env.master.coverage.cg_addr">
          <cginstSourceId file="1" line="1" inlineCount="1"/>
          <cgSourceId file="1" line="1" inlineCount="1"/>
        </cgId>
        <coverpoint name="addr" key="0">
          <options/>
          <coverpointBin name="low" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="36"/>
            </range>
          </coverpointBin>
          <coverpointBin name="med" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="30"/>
            </range>
          </coverpointBin>
          <coverpointBin name="high" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="34"/>
            </range>
          </coverpointBin>
        </coverpoint>
      </cgInstance>
      <cgInstance name="uvm_test_top.env.sdt_slave.coverage.cg_addr" key="0">
        <options/>
        <cgId cgName="uvm_test_top.env.master.coverage.cg_addr" moduleName="uvm_test_top.env.master.coverage.cg_addr">
          <cginstSourceId file="1" line="1" inlineCount="1"/>
          <cgSourceId file="1" line="1" inlineCount="1"/>
        </cgId>
        <coverpoint name="addr" key="0">
          <options/>
          <coverpointBin name="low" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="36"/>
            </range>
          </coverpointBin>
          <coverpointBin name="med" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="30"/>
            </range>
          </coverpointBin>
          <coverpointBin name="high" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="34"/>
            </range>
          </coverpointBin>
        </coverpoint>
      </cgInstance>
    </covergroupCoverage>
    <covergroupCoverage>
      <cgInstance name="uvm_test_top.env.master.coverage.cg_delays" key="0">
        <options/>
        <cgId cgName="uvm_test_top.env.master.coverage.cg_delays" moduleName="uvm_test_top.env.master.coverage.cg_delays">
          <cginstSourceId file="1" line="1" inlineCount="1"/>
          <cgSourceId file="1" line="1" inlineCount="1"/>
        </cgId>
        <coverpoint name="delay_cycles" key="0">
          <options/>
          <coverpointBin name="0" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="0"/>
            </range>
          </coverpointBin>
          <coverpointBin name="[1,5]" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="77"/>
            </range>
          </coverpointBin>
          <coverpointBin name="[6,15]" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="23"/>
            </range>
          </coverpointBin>
          <coverpointBin name="&gt;15" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="0"/>
            </range>
          </coverpointBin>
        </coverpoint>
      </cgInstance>
      <cgInstance name="uvm_test_top.env.sdt_slave.coverage.cg_delays" key="0">
        <options/>
        <cgId cgName="uvm_test_top.env.master.coverage.cg_delays" moduleName="uvm_test_top.env.master.coverage.cg_delays">
          <cginstSourceId file="1" line="1" inlineCount="1"/>
          <cgSourceId file="1" line="1" inlineCount="1"/>
        </cgId>
        <coverpoint name="delay_cycles" key="0">
          <options/>
          <coverpointBin name="0" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="0"/>
            </range>
          </coverpointBin>
          <coverpointBin name="[1,5]" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="77"/>
            </range>
          </coverpointBin>
          <coverpointBin name="[6,15]" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="23"/>
            </range>
          </coverpointBin>
          <coverpointBin name="&gt;15" type="bins" key="0">
            <range from="-1" to="-1">
              <contents coverageCount="0"/>
            </range>
          </coverpointBin>
        </coverpoint>
      </cgInstance>
    </covergroupCoverage>
  </instanceCoverages>
</UCIS>
```
</details>

The XML file contains 2x `<covergroupCoverage>`, each of which contains two `<cgInstance>`. When viewing with `pyucis_viewer`, the `covergroupCoverage` sections are labeled "default" since multiple covergroups exist beneath them.
![image](https://github.com/fvutils/pyucis/assets/47347446/591760df-9328-4079-a2b3-4d2c14abaf58)

When merging this coverage file with another coverage file from a similar run, the coverage merger only identifies one covergroup name (default), and thus doesn't include all nested covergroups. In the following, see that only the last covergroup from each section is included (`cg_delays`)
![image](https://github.com/fvutils/pyucis/assets/47347446/443959fe-e45b-4cbb-af59-c2a58ca81680)

This PR fixes this by including all covergroups under a heading, not just the final one discovered (the one coming last in an alphabetical sorting). In the end, all covergroups are placed under a single "default" heading.

![image](https://github.com/fvutils/pyucis/assets/47347446/bbd98302-15ce-4732-ad6e-e575bbfb5191)

An alternative to this PR would be to modify the underlying database structure such that each `covergroupCoverage` is only associated with one `cgInstance`, but this might break spec conformance. Alternatively, a `userAttr` could be added to each `covergroupCoverage` to name the `covergroupCoverage` since adding a `name` entry directly in the XML field does not conform to spec.